### PR TITLE
Allow add-on to work with top level domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installation
 The addon is built using the [Add-on SDK][] from Mozilla.
 
 ```
-$ cfx xpi
+$ jpm xpi
 ```
 
 Official releases can be installed from [addons.mozilla.org][].

--- a/lib/main.js
+++ b/lib/main.js
@@ -57,17 +57,17 @@ exports.main = function(options, callbacks) {
     debug = {
         // We intercept requests to FQDNs matching these patterns.
         fqdns: [
-            /^www\.mediawiki\.org$/,
-            /^([0-9A-Za-z]|-)+\.wikibooks\.org$/,
-            /^([0-9A-Za-z]|-)+\.wikidata\.org$/,
-            /^([0-9A-Za-z]|-)+\.wikimedia\.org$/,
-            /^([0-9A-Za-z]|-)+\.wikinews\.org$/,
-            /^([0-9A-Za-z]|-)+\.wikipedia\.org$/,
-            /^([0-9A-Za-z]|-)+\.wikiquote\.org$/,
-            /^([0-9A-Za-z]|-)+\.wikisource\.org$/,
-            /^([0-9A-Za-z]|-)+\.wikiversity\.org$/,
-            /^([0-9A-Za-z]|-)+\.wikivoyage\.org$/,
-            /^([0-9A-Za-z]|-)+\.wiktionary\.org$/,
+            /^(www\.)?mediawiki\.org$/,
+            /^(([0-9A-Za-z]|-)+\.)?wikibooks\.org$/,
+            /^(([0-9A-Za-z]|-)+\.)?wikidata\.org$/,
+            /^(([0-9A-Za-z]|-)+\.)?wikimedia\.org$/,
+            /^(([0-9A-Za-z]|-)+\.)?wikinews\.org$/,
+            /^(([0-9A-Za-z]|-)+\.)?wikipedia\.org$/,
+            /^(([0-9A-Za-z]|-)+\.)?wikiquote\.org$/,
+            /^(([0-9A-Za-z]|-)+\.)?wikisource\.org$/,
+            /^(([0-9A-Za-z]|-)+\.)?wikiversity\.org$/,
+            /^(([0-9A-Za-z]|-)+\.)?wikivoyage\.org$/,
+            /^(([0-9A-Za-z]|-)+\.)?wiktionary\.org$/,
             /^(tools(-static)?)\.wmflabs\.org$/,
         ],
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "icon": "data/icon.png",
     "icon64": "data/icon_64.png",
     "license": "Apache 2.0",
+    "main": "lib/main.js",
     "permissions": {
         "private-browsing": true
     },
-    "version": "0.3"
+    "version": "0.4.0"
 }


### PR DESCRIPTION
We have some not-like-the-others domains (I'm looking at you
https://wikisource.org/) that the previous host patterns did not match.
Just to make things easy, update most of the patterns to make the
hostname component optional.