### PR TITLE
Use an SPDX identifier as "license" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ],
     "icon": "data/icon.png",
     "icon64": "data/icon_64.png",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "main": "lib/main.js",
     "permissions": {
         "private-browsing": true


### PR DESCRIPTION
As recommended by MDN:
https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/package_json#license