### PR TITLE
Fix Kibana log link

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -176,7 +176,7 @@ var wikiPatterns = [
           ],
           contentScriptFile: self.data.url("getRequestId.js"),
           onMessage: function (reqid) {
-              tabs.open("https://logstash.wikimedia.org/#/dashboard/elasticsearch/request-id?id=" + reqid);
+              tabs.open("https://logstash.wikimedia.org/app/kibana#/dashboard/x-debug?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-1h,mode:quick,to:now))&_a=(filters:!((%27$state%27:(store:appState),meta:(alias:!n,disabled:!f,index:%27logstash-*%27,key:_type,negate:!f,value:mediawiki),query:(match:(_type:(query:mediawiki))))),options:(darkTheme:!f),panels:!((col:1,id:Events-Over-Time,panelIndex:14,row:1,size_x:12,size_y:2,type:visualization),(col:1,columns:!(level,channel,host,wiki,message),id:MediaWiki-Events-List,panelIndex:15,row:3,size_x:12,size_y:11,sort:!(%27@timestamp%27,desc),type:search)),query:(query_string:(analyze_wildcard:!t,query:%27reqId:%22" + encodeURI(reqid) + "%22%27)),title:x-debug,uiState:())");
           }
       }),
       contextmenu.Item({


### PR DESCRIPTION
The upgrade from Kibana3 to Kibana4 removed the request-id dashboard
from https://logstash.wikimedia.org. With Kibana4 the full dashboard
configuration including the panels that are used and any search terms
are passed in the `_g` URL parameter.

Closes #15